### PR TITLE
package.json is now pointing to lib/index.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # aws-lambda-helper
 Collection of helper methods for lambda
 
-[![Build Status](https://travis-ci.org/tcdl/aws-lambda-helper.svg?branch=master)](https://travis-ci.org/tcdl/aws-lambda-helper)
-[![codecov.io](https://codecov.io/github/tcdl/aws-lambda-helper/coverage.svg?branch=master)](https://codecov.io/github/tcdl/aws-lambda-helper?branch=master)
+[![Build Status](https://travis-ci.org/numo-labs/aws-lambda-helper.svg?branch=master)](https://travis-ci.org/numo-labs/aws-lambda-helper)
+[![codecov.io](https://codecov.io/github/numo-labs/aws-lambda-helper/coverage.svg?branch=master)](https://codecov.io/github/numo-labs/aws-lambda-helper?branch=master)
 
 ## Installation
 `$ npm install aws-lambda-helper --save`
@@ -11,13 +11,16 @@ Collection of helper methods for lambda
 
 ```javascript
   var AwsHelper = require('aws-lambda-helper');
-  var AWS = require('aws-sdk');
 
-  //Initialise the helper by passing in aws-sdk and context 
-  var awsHelper = AwsHelper(AWS, context);
+  exports.handler = function(event, context) {
+    ...
+    //Initialise the helper by passing in the context
+    var awsHelper = AwsHelper(context);
+    ...
+  }
 ```
 
-### Invoke a Lamda function 
+### Invoke a Lamda function
 
 ```javascript
 
@@ -26,9 +29,9 @@ Collection of helper methods for lambda
 
   exports.handler = function(event, context){
     // assume : context.invokedFunctionArn = invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789:function:mylambda:prod'
-    
-    //Initialise the helper by passing in aws-sdk and context
-    var awsHelper = AwsHelper(AWS, context);
+
+    //Initialise the helper by passing in the context
+    var awsHelper = AwsHelper(context);
 
     console.log(awsHelper.env); //prints: prod
     console.log(awsHelper.region); //prints: eu-west-1
@@ -44,4 +47,6 @@ Collection of helper methods for lambda
       context.succeed(data);
     });
   }
-``
+```
+
+### Invoke a Lamda function

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "aws-lambda-helper",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Collection of helper methods for lambda",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "scripts": {
     "nocov": "node ./node_modules/.bin/mocha test/*/*.js",
     "test": "npm run lint && npm run coverage",


### PR DESCRIPTION
This will fix https://github.com/numo-labs/aws-lambda-helper/issues/15 where package.json main entry was pointing to `src/index.js` instead of `lib/index.js`

This will fix https://github.com/numo-labs/aws-lambda-helper/issues/13 where the badges were linking to `tcdl` instead of `numo-labs`
