### PR TITLE
Removed lib folder from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-lib/
 .travis.yml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-helper",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Collection of helper methods for lambda",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This fixes https://github.com/numo-labs/aws-lambda-helper/issues/17 which ignored the lib folder during a npm publish.
