### PR TITLE
Moving `aws-sdk` to a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
   "license": "GPL-2.0",
   "homepage": "https://github.com/tcdl/aws-lambda-helper",
   "devDependencies": {
-    "aws-sdk": "^2.2.40",
     "eslint": "^1.10.3",
     "eslint-config-semistandard": "^5.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "simple-mock": "^0.6.0"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.3.9"
   }
 }


### PR DESCRIPTION
`aws-sdk` should be listed as a production dependency instead of a development dependency. 
