### PR TITLE
Adding JSON logging as a function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,39 @@ It can be used as follows:
   
 ```
 
+### Logging JSON messages
+
+```js
+var AwsHelper = require('aws-lambda-helper');
+
+exports.handler = function(event, context){
+  // assume : context.invokedFunctionArn = invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789:function:mylambda:prod'
+
+  //Initialise the helper by passing in the context
+  AwsHelper.init(context);
+
+  var log = AwsHelper.Logger('example');
+
+  log.info();     // Returns a boolean: is the "info" level enabled?
+  // This is equivalent to `log.isInfoEnabled()` or
+  // `log.isEnabledFor(INFO)` in log4j.
+
+  log.info('hi');                     // Log a simple string message (or number).
+  log.info('hi %s', bob, anotherVar); // Uses `util.format` for msg formatting.
+
+  log.info({foo: 'bar'}, 'hi');
+  // The first field can optionally be a "fields" object, which
+  // is merged into the log record.
+
+  log.info(err);  // Special case to log an `Error` instance to the record.
+  // This adds an "err" field with exception details
+  // (including the stack) and sets "msg" to the exception
+  // message.
+  log.info(err, 'more on this: %s', more);
+  // ... or you can specify the "msg".
+
+  log.info({foo: 'bar', err: err}, 'some msg about this error');
+  // To pass in an Error *and* other fields, use the `err`
+  // field name for the Error instance.
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,9 @@ var AwsHelper = {
 };
 
 // initialisation method (Optional)
-function init (context) {
+function init (context, event) {
   AwsHelper._context = context;
+  AwsHelper._event = event;
   AwsHelper._Lambda = null;
   AwsHelper._SNS = null;
   AwsHelper._DynamoDB = null;
@@ -188,13 +189,15 @@ function clone (obj) {
 AwsHelper.Logger = function (tags) {
   tags = tags || [];
   var context = AwsHelper._context || {};
-  var clientContext = context.clientContext || {};
+  var event = AwsHelper._event || {};
+  var headers = event.headers || {};
+
   var log = bunyan.createLogger({
     name: context.functionName || context.invokedFunctionArn || 'unknown',
-    invokedFunctionArn: context.invokedFunctionArn,
-    version: context.functionVersion,
-    traceableId: clientContext.traceableId || '',
-    tags: Array.isArray(tags) ? tags : [tags]
+    '#invoked_function_arn': context.invokedFunctionArn,
+    '#version': context.functionVersion,
+    '#traceable_id': headers['trace-request-id'] || '',
+    '#tags': Array.isArray(tags) ? tags : [tags]
   });
   return log;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var AWS = require('aws-sdk');
+var bunyan = require('bunyan');
+
 var AwsHelper = {
   _AWS: AWS,
   _context: null,
@@ -182,6 +184,19 @@ AwsHelper.failOnError = function (err, event, context) {
 function clone (obj) {
   return JSON.parse(JSON.stringify(obj));
 }
+
+AwsHelper.Logger = function (name) {
+  var context = AwsHelper._context || {};
+  var clientContext = context.clientContext || {};
+  var log = bunyan.createLogger({
+    name: context.functionName || context.invokedFunctionArn || name,
+    invokedFunctionArn: context.invokedFunctionArn,
+    version: context.functionVersion,
+    traceableId: clientContext.traceableId || '',
+    module: name || ''
+  });
+  return log;
+};
 
 module.exports = AwsHelper;
 module.exports.getEnvironment = AwsHelper.getEnvironment;

--- a/lib/index.js
+++ b/lib/index.js
@@ -194,10 +194,10 @@ AwsHelper.Logger = function (tags) {
 
   var log = bunyan.createLogger({
     name: context.functionName || context.invokedFunctionArn || 'unknown',
-    '#invoked_function_arn': context.invokedFunctionArn,
-    '#version': context.functionVersion,
-    '#traceable_id': headers['trace-request-id'] || '',
-    '#tags': Array.isArray(tags) ? tags : [tags]
+    'invoked_function_arn': context.invokedFunctionArn,
+    version: context.functionVersion,
+    'traceable_id': headers['trace-request-id'] || '',
+    tags: Array.isArray(tags) ? tags : [tags]
   });
   return log;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,15 +185,16 @@ function clone (obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-AwsHelper.Logger = function (name) {
+AwsHelper.Logger = function (tags) {
+  tags = tags || [];
   var context = AwsHelper._context || {};
   var clientContext = context.clientContext || {};
   var log = bunyan.createLogger({
-    name: context.functionName || context.invokedFunctionArn || name,
+    name: context.functionName || context.invokedFunctionArn || 'unknown',
     invokedFunctionArn: context.invokedFunctionArn,
     version: context.functionVersion,
     traceableId: clientContext.traceableId || '',
-    module: name || ''
+    tags: Array.isArray(tags) ? tags : [tags]
   });
   return log;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-helper",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Collection of helper methods for lambda",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
     "aws-sdk": "^2.2.40",
     "eslint": "^1.10.3",
     "eslint-config-semistandard": "^5.0.0",
+    "intercept-stdout": "^0.1.2",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "simple-mock": "^0.6.0"
+  },
+  "dependencies": {
+    "bunyan": "^1.8.1"
   }
 }

--- a/test/lib/logger.js
+++ b/test/lib/logger.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var assert = require('assert');
+var AwsHelper = require('./../../lib/index');
+var interceptStdout = require('intercept-stdout');
+
+describe('AwsHelper.Logger', function () {
+  it('should accept a parameter which is optional with no value', function (done) {
+    var context = {
+      'functionName': 'aws-canary-lambda',
+      'invokedFunctionArn': 'arn:aws:lambda:eu-west-1:123456789:function:aws-canary-lambda:prod'
+    };
+    AwsHelper.init(context);
+    var logger = AwsHelper.Logger();
+    assert.equal(logger.fields.module, '');
+    done();
+  });
+
+  it('should accept a parameter which is optional with a value', function (done) {
+    var context = {
+      'functionName': 'aws-canary-lambda',
+      'invokedFunctionArn': 'arn:aws:lambda:eu-west-1:123456789:function:aws-canary-lambda:prod'
+    };
+    AwsHelper.init(context);
+    var logger = AwsHelper.Logger('hello');
+    assert.equal(logger.fields.module, 'hello');
+    done();
+  });
+
+  describe('AwsHelper.Logger#info', function () {
+    it('should log a json message', function (done) {
+      var context = {
+        'functionName': 'aws-canary-lambda',
+        'invokedFunctionArn': 'arn:aws:lambda:eu-west-1:123456789:function:aws-canary-lambda:prod'
+      };
+      AwsHelper.init(context);
+      var logger = AwsHelper.Logger();
+      var stdout = '';
+      var unhook = interceptStdout(function (text) {
+        stdout += text;
+      });
+      logger.info('hello in stdout');
+      setImmediate(function () {
+        unhook();
+        var json = JSON.parse(stdout);
+        assert.equal(json.msg, 'hello in stdout');
+        done();
+      });
+    });
+  });
+});

--- a/test/lib/logger.js
+++ b/test/lib/logger.js
@@ -12,7 +12,7 @@ describe('AwsHelper.Logger', function () {
     };
     AwsHelper.init(context);
     var logger = AwsHelper.Logger();
-    assert.equal(logger.fields.module, '');
+    assert.equal(logger.fields.tags.length, 0);
     done();
   });
 
@@ -23,7 +23,7 @@ describe('AwsHelper.Logger', function () {
     };
     AwsHelper.init(context);
     var logger = AwsHelper.Logger('hello');
-    assert.equal(logger.fields.module, 'hello');
+    assert.equal(logger.fields.tags, 'hello');
     done();
   });
 
@@ -34,7 +34,7 @@ describe('AwsHelper.Logger', function () {
         'invokedFunctionArn': 'arn:aws:lambda:eu-west-1:123456789:function:aws-canary-lambda:prod'
       };
       AwsHelper.init(context);
-      var logger = AwsHelper.Logger();
+      var logger = AwsHelper.Logger(['stdout', 'test']);
       var stdout = '';
       var unhook = interceptStdout(function (text) {
         stdout += text;


### PR DESCRIPTION
This commit introduces a new method of logging from within AWS Lambda's. 

It delegates to Bunyan and produces log messages in the structure defined below:

``` json
{
    "name": "aws-canary-lambda",
    "invokedFunctionArn": "arn:aws:lambda:eu-west-1:123456789:function:aws-canary-lambda:1",
    "traceableId": "some-id",
    "module": "where-i-am-from",
    "hostname": "magellanic",
    "version": "1",
    "pid": 25728,
    "level": 30,
    "msg": "hello in stdout",
    "time": "2016-05-06T11:48:44.207Z",
    "v": 0
}
```

As seen above this function also reads the current context of the lambda and populates some common fields to embelish logs with some added features, which could be indexed if sent to Elasticsearch.
