### PR TITLE
Forwarding tracing headers when invoking lambdas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ exports.handler = function(event, context){
   // assume : context.invokedFunctionArn = invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789:function:mylambda:prod'
 
   //Initialise the helper by passing in the context
-  AwsHelper.init(context);
+  AwsHelper.init(context, event);
 
   var log = AwsHelper.Logger('example');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,11 +115,10 @@ AwsHelper.Lambda.invoke = function (params, cb) {
   // }
   //
   // Where { ... } is the current params.Payload.
-  if (AwsHelper._event &&
-      AwsHelper._event.headers &&
-      AwsHelper._event.headers['trace-request-id']) {
+  var headers = AwsHelper._getEventHeaders();
+  if (headers['trace-request-id']) {
     params.Payload.headers = {
-      'trace-request-id': AwsHelper._event.headers['trace-request-id']
+      'trace-request-id': headers['trace-request-id']
     };
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,6 +102,26 @@ AwsHelper.Lambda.invoke = function (params, cb) {
     params.FunctionName = AwsHelper.account + ':' + params.FunctionName;
   }
 
+  // If a trace-request-id is present on the header of the consuming lambda
+  // then we forward this the new lambda instance when it is being invoked.
+  //
+  // Eventually this payload should be move to:
+  // {
+  //    body: { ... },
+  //    headers: {
+  //     'trace-request-id': 'some-id'
+  //    }
+  // }
+  //
+  // Where { ... } is the current params.Payload.
+  if (AwsHelper._event &&
+      AwsHelper._event.headers &&
+      AwsHelper._event.headers['trace-request-id']) {
+    params.Payload.headers = {
+      'trace-request-id': AwsHelper._event.headers['trace-request-id']
+    };
+  }
+
   AwsHelper._initLambdaObject();
 
   var p = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,8 @@ AwsHelper.Lambda.invoke = function (params, cb) {
   }
 
   // If a trace-request-id is present on the header of the consuming lambda
-  // then we forward this the new lambda instance when it is being invoked.
+  // then we will forward the tracing header to the new lambda instance when
+  // being invoked.
   //
   // Eventually this payload should be move to:
   // {


### PR DESCRIPTION
This will forward the trace-request-id to the invoked lambda if present in the original event.

This is being patched in for now to maintain backwards compatibility, however eventually I would like to move all of our Payloads to a format like:

``` js
{
    body: { ... },
    headers: {
        'trace-request-id': 'some-id'
    }
}
```

However as it currently the headers attribute is being re-assigned to a new object.

> **Note:** This assumes that we are not currently using the attribute `headers` on the Payload, if we are then we have two options. Either go straight to the (body / headers) change noted above, causing a lot of changes throughout many services. Or we can add the logic to check for the property and then extend it, if it already exists.
