### PR TITLE
Improve SNS by sending and receiving trace headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,11 +59,6 @@ AwsHelper._parseInvokedFunctionArn = function (invokedFunctionArn) {
 AwsHelper._getEventHeaders = function () {
   var event = AwsHelper._event || {};
 
-  // If we have no event we will have no headers.
-  if (!event) {
-    return {};
-  }
-
   // This is a event header from an invocation of lambda or a API Gateway.
   var headers = event.headers;
   if (headers) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,8 @@ var AwsHelper = {
   Lambda: {},
   SNS: {},
   DynamoDB: {},
-  init: init
+  init: init,
+  log: {}
 };
 
 // initialisation method (Optional)
@@ -27,6 +28,7 @@ function init (context, event) {
   AwsHelper._DynamoDB = null;
   AwsHelper._parseInvokedFunctionArn(context.invokedFunctionArn);
   AwsHelper._AWS.config.region = AwsHelper.region;
+  AwsHelper.log = AwsHelper.Logger();
   return AwsHelper;
 }
 
@@ -49,6 +51,39 @@ AwsHelper._parseInvokedFunctionArn = function (invokedFunctionArn) {
     return AwsHelper;
   }
   throw new Error('Unexpected invokedFunctionArn format: ' + invokedFunctionArn);
+};
+
+// This is a helper function that retrieves the headers from the event, that
+// depending on if it is an event from SNS, a lambda invoke, etc will return a
+// like-for-like object.
+AwsHelper._getEventHeaders = function () {
+  var event = AwsHelper._event || {};
+
+  // If we have no event we will have no headers.
+  if (!event) {
+    return {};
+  }
+
+  // This is a event header from an invocation of lambda or a API Gateway.
+  var headers = event.headers;
+  if (headers) {
+    return headers;
+  }
+
+  if (event.Records && event.Records[0]) {
+    var record = event.Records[0];
+    var attrs = record.Sns.MessageAttributes;
+    if (attrs && Object.keys(attrs).length > 0) {
+      headers = {};
+      Object.keys(attrs).map(function (key) {
+        headers[key] = attrs[key].Value;
+      });
+      return headers;
+    }
+  }
+
+  // Default to an empty object
+  return {};
 };
 
 // backwards compatability to retrieve the env from a givien context.
@@ -112,11 +147,22 @@ AwsHelper.SNS.publish = function (params, cb) {
 
   AwsHelper._initSNSObject();
 
+  var headers = AwsHelper._getEventHeaders();
+
   var p = {
     Message: params.Message,
     MessageStructure: params.MessageStructure || 'json',
     TopicArn: params.TopicArn
   };
+
+  if (headers['trace-request-id']) {
+    p.MessageAttributes = {
+      'trace-request-id': {
+        DataType: 'String',
+        StringValue: headers['trace-request-id']
+      }
+    };
+  }
 
   return AwsHelper._SNS.publish(p, cb);
 };
@@ -189,8 +235,7 @@ function clone (obj) {
 AwsHelper.Logger = function (tags) {
   tags = tags || [];
   var context = AwsHelper._context || {};
-  var event = AwsHelper._event || {};
-  var headers = event.headers || {};
+  var headers = AwsHelper._getEventHeaders();
 
   var log = bunyan.createLogger({
     name: context.functionName || context.invokedFunctionArn || 'unknown',

--- a/test/lib/logger.js
+++ b/test/lib/logger.js
@@ -33,7 +33,7 @@ describe('AwsHelper.Logger', function () {
         'functionName': 'aws-canary-lambda',
         'invokedFunctionArn': 'arn:aws:lambda:eu-west-1:123456789:function:aws-canary-lambda:prod'
       };
-      AwsHelper.init(context);
+      AwsHelper.init(context, { headers: { 'trace-request-id': 'an id' } });
       var logger = AwsHelper.Logger(['stdout', 'test']);
       var stdout = '';
       var unhook = interceptStdout(function (text) {
@@ -44,6 +44,58 @@ describe('AwsHelper.Logger', function () {
         unhook();
         var json = JSON.parse(stdout);
         assert.equal(json.msg, 'hello in stdout');
+        done();
+      });
+    });
+
+    it('should log a json message with traceable_id', function (done) {
+      var context = {
+        'functionName': 'aws-canary-lambda',
+        'invokedFunctionArn': 'arn:aws:lambda:eu-west-1:123456789:function:aws-canary-lambda:prod'
+      };
+      AwsHelper.init(context, { headers: { 'trace-request-id': 'an id' } });
+      var logger = AwsHelper.Logger(['stdout', 'test']);
+      var stdout = '';
+      var unhook = interceptStdout(function (text) {
+        stdout += text;
+      });
+      logger.info('hello in stdout');
+      setImmediate(function () {
+        unhook();
+        var json = JSON.parse(stdout);
+        assert.equal(json.traceable_id, 'an id');
+        done();
+      });
+    });
+
+    it('should log a json message with traceable_id', function (done) {
+      var context = {
+        'functionName': 'aws-canary-lambda',
+        'invokedFunctionArn': 'arn:aws:lambda:eu-west-1:123456789:function:aws-canary-lambda:prod'
+      };
+      AwsHelper.init(context, {
+        Records: [
+          {
+            Sns: {
+              MessageAttributes: {
+                'trace-request-id': {
+                  Value: 'an id'
+                }
+              }
+            }
+          }
+        ]
+      });
+      var logger = AwsHelper.Logger(['stdout', 'test']);
+      var stdout = '';
+      var unhook = interceptStdout(function (text) {
+        stdout += text;
+      });
+      logger.info('hello in stdout');
+      setImmediate(function () {
+        unhook();
+        var json = JSON.parse(stdout);
+        assert.equal(json.traceable_id, 'an id');
         done();
       });
     });


### PR DESCRIPTION
Every message that is now sent using SNS by this module will forward tracing headers if they are present in the current's lambda's event .
