### PR TITLE
Pass all headers along to other lambdas

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,10 +126,8 @@ AwsHelper.Lambda.invoke = function (params, cb) {
   //
   // Where { ... } is the current params.Payload.
   var headers = AwsHelper._getEventHeaders();
-  if (headers['trace-request-id']) {
-    params.Payload.headers = {
-      'trace-request-id': headers['trace-request-id']
-    };
+  if (Object.keys(headers).length > 0) {
+    params.Payload.headers = headers;
   }
 
   AwsHelper._initLambdaObject();
@@ -180,14 +178,7 @@ AwsHelper.SNS.publish = function (params, cb) {
     TopicArn: params.TopicArn
   };
 
-  if (headers['trace-request-id']) {
-    p.MessageAttributes = {
-      'trace-request-id': {
-        DataType: 'String',
-        StringValue: headers['trace-request-id']
-      }
-    };
-
+  if (Object.keys(headers).length > 0) {
     var message;
 
     try {
@@ -276,10 +267,12 @@ AwsHelper.Logger = function (tags) {
 
   var log = bunyan.createLogger({
     name: context.functionName || context.invokedFunctionArn || 'unknown',
+    level: headers['request-log-level'] || process.env.LOG_LEVEL || 'info',
     'invoked_function_arn': context.invokedFunctionArn,
     version: context.functionVersion,
     'traceable_id': headers['trace-request-id'] || '',
-    tags: Array.isArray(tags) ? tags : [tags]
+    tags: Array.isArray(tags) ? tags : [tags],
+    headers: headers
   });
   return log;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-helper",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Collection of helper methods for lambda",
   "main": "lib/index.js",
   "scripts": {

--- a/test/lib/dynamodb.js
+++ b/test/lib/dynamodb.js
@@ -118,5 +118,5 @@ describe('AwsHelper.DynamoDB', function () {
       assert.deepEqual(mock.firstCall.arg, expected_params);
       done();
     });
-   });
+  });
 });

--- a/test/lib/sns.js
+++ b/test/lib/sns.js
@@ -116,13 +116,7 @@ describe('AwsHelper.SNS', function () {
             })
           }),
           MessageStructure: 'json',
-          TopicArn: topic,
-          MessageAttributes: {
-            'trace-request-id': {
-              DataType: 'String',
-              StringValue: 'an id'
-            }
-          }
+          TopicArn: topic
         };
         assert.deepEqual(p, params);
         cb(null, {MessageId: 'mock-message-id'});


### PR DESCRIPTION
This will pass all headers along to each lambda, whether by invoking a
lambda directly or by publishing to SNS.
