### PR TITLE
Publish SNS events when passing search results to websocket server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -365,10 +365,35 @@ function pushToSocketServer (params, callback) {
     'method': 'POST',
     body: params
   };
-
+  // trigger SNS event with search result - for development right now, so ignore errors
+  pushToSNSTopic(params, (err) => {
+    if (err) { AwsHelper.log.error(params, `Failed to publish SNS event to ${process.env.SEARCH_RESULT_TOPIC} `); }
+  });
   httpRequest(options, callback);
 }
 AwsHelper.pushToSocketServer = pushToSocketServer; // export for testing
+
+/**
+ * pushToSNSTopic emits an event to an SNS topic
+ * with all the information required to forward a search result item
+ * on to the Client that requested the search.
+ * @param {String} params - the object containing all the body to send (see below)
+ params = { // see: https://github.com/numo-labs/aws-lambda-helper/issues/40
+   id: clientId,
+   searchId: searchId,
+   userId: userId,
+   items: Array.isArray(json) ? json : [json] // always send an array of items
+ }
+ * @param {Function} callback - callaback executed with (err, data)
+ */
+function pushToSNSTopic (params, callback) {
+  AwsHelper.SNS.publish({
+    Message: {
+      default: params
+    },
+    TopicArn: process.env.SEARCH_RESULT_TOPIC
+  }, callback);
+}
 
 var resultBucket = new AWS.S3({params: {Bucket: process.env.AWS_S3_SEARCH_RESULT_BUCKET}});
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -387,6 +387,9 @@ AwsHelper.pushToSocketServer = pushToSocketServer; // export for testing
  * @param {Function} callback - callaback executed with (err, data)
  */
 function pushToSNSTopic (params, callback) {
+  if (!process.env.SEARCH_RESULT_TOPIC) {
+    return callback(new Error('SEARCH_RESULT_TOPIC is not defined'));
+  }
   AwsHelper.SNS.publish({
     Message: {
       default: params

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-helper",
-  "version": "2.13.4",
+  "version": "2.14.0",
   "description": "Collection of helper methods for lambda",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
It is intended to refactor the flow of search results back to the client by passing through redis pubsub to ensure that events are received by the socket server instance that the browser client is connected to. In order to commence this search results will be passed via SNS to a lambda pushing them to redis pubsub.

Once the websocket server is correctly reading search results from redis the direct http POST will be removed.
