### PR TITLE
Move aws-sdk to full dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "license": "GPL-2.0",
   "homepage": "https://github.com/tcdl/aws-lambda-helper",
   "devDependencies": {
-    "aws-sdk": "^2.3.14",
     "engine.io": "^1.6.9",
     "engine.io-client": "^1.6.9",
     "env2": "^2.1.0",
@@ -29,6 +28,7 @@
     "simple-mock": "^0.7.0"
   },
   "dependencies": {
+    "aws-sdk": "^2.3.14",
     "bunyan": "^1.8.1"
   }
 }


### PR DESCRIPTION
The module is `require`-d at runtime so should be listed as a full dependency.
