### PR TITLE
Improve error logging in sns punlish method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -368,7 +368,7 @@ function pushToSocketServer (params, callback) {
   // trigger SNS event with search result - for development right now, so ignore errors
   pushToSNSTopic(params, (err) => { // @lennym to update this ...
     /* istanbul ignore else */
-    if (err) { AwsHelper.log.error(params, `Failed to publish SNS event to ${process.env.SEARCH_RESULT_TOPIC} `); }
+    if (err) { AwsHelper.log.error({ params: params, error: err }, `Failed to publish SNS event to ${process.env.SEARCH_RESULT_TOPIC}`); }
   });
   httpRequest(options, callback);
 }


### PR DESCRIPTION
The log written when SNS errors doesn't actually currently include the error, so it's failing when published, but I have no idea why.

Hopefully this will shed some light on it.
