### PR TITLE
version bump to 2.15.1 to include improved SNS error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-helper",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Collection of helper methods for lambda",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
version 2.15.0 had already been published to NPM _without_ the improved logging so need to bump to `2.15.1` so we can re-publish. 👍 
