### PR TITLE
Require `params.id` when pushing results to client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -361,6 +361,11 @@ AwsHelper.getRecordFromS3 = getRecord; // export for testing
  */
 
 AwsHelper.pushResultToClient = function (params, callback) {
+  if (!params.id) {
+    const msg = 'id property is required to return results to client';
+    AwsHelper.log.error({data: params}, msg);
+    return callback(new Error(msg));
+  }
   // push to WebSocket Server
   pushToSNSTopic(params, function (err, data) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-helper",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Collection of helper methods for lambda",
   "main": "lib/index.js",
   "scripts": {

--- a/test/lib/pushResultToClient.test.js
+++ b/test/lib/pushResultToClient.test.js
@@ -3,7 +3,7 @@ require('env2')('.env');
 var assert = require('assert');
 var AwsHelper = require('./../../lib/index');
 
-describe('pushToSocketServer', function () {
+describe('pushResultToClient', function () {
   before('Connect to WebSocket Server', function (done) {
     AwsHelper.init({
       invokedFunctionArn: process.env.INVOKED_FUNCTION_ARN
@@ -47,6 +47,21 @@ describe('pushToSocketServer', function () {
         'Error thrown (as expected)');
       // restore the environment variable for other tests:
       process.env.SEARCH_RESULT_TOPIC = 'search-results-v1';
+      done();
+    });
+  });
+
+  it('calls back with error if no id property is present on the params', (done) => {
+    var params = {
+      searchId: 'ABC',
+      userId: 'TESTUSERID',
+      items: [{
+        id: 123, hello: 'world', title: 'amazing holiday',
+        url: 'userId/connectionId/bucketId/123'
+      }]
+    };
+    AwsHelper.pushResultToClient(params, function (err, res) {
+      assert(err);
       done();
     });
   });


### PR DESCRIPTION
The websocket server cannot reconcile results with the client if no room id is provided. This means that it should not be possible to call `pushResultToClient` without an `id` property on the parameters sent.
