### PR TITLE
Remove items with no url prop when saving to S3 on publish

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -312,9 +312,12 @@ var resultBucket = new AWS.S3({ params:
  * which is the url
  */
 function saveRecord (params, callback) {
-  var countdown = params.items.length;
-  // console.log(params.items);
-  params.items.forEach(function (item) {
+  const filtered = params.items.filter((item) => item.url);
+  var countdown = filtered.length;
+  if (countdown === 0) {
+    return callback();
+  }
+  filtered.forEach(function (item) {
     var env = AwsHelper.env; // remember to Initialise this!
     var s3params = {
       Bucket: process.env.AWS_S3_SEARCH_RESULT_BUCKET,

--- a/lib/index.js
+++ b/lib/index.js
@@ -312,7 +312,9 @@ var resultBucket = new AWS.S3({ params:
  * which is the url
  */
 function saveRecord (params, callback) {
-  const filtered = params.items.filter((item) => item.url);
+  const filtered = params.items.filter((item) => {
+    return item.type && item.type.match(/^tile|package$/);
+  });
   var countdown = filtered.length;
   if (countdown === 0) {
     return callback();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-helper",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "description": "Collection of helper methods for lambda",
   "main": "lib/index.js",
   "scripts": {

--- a/test/lib/pushResultToClient.test.js
+++ b/test/lib/pushResultToClient.test.js
@@ -27,11 +27,11 @@ describe('pushResultToClient', function () {
       userId: 'TESTUSERID',
       items: [
         {
-          id: 123, hello: 'world', title: 'amazing holiday',
+          type: 'package', id: 123, hello: 'world', title: 'amazing holiday',
           url: 'userId/connectionId/bucketId/123'
         },
         {
-          id: 456, hello: 'world', title: 'not amazing holiday',
+          type: 'package', id: 456, hello: 'world', title: 'not amazing holiday',
           url: 'userId/connectionId/bucketId/456'
         }
       ]
@@ -54,11 +54,11 @@ describe('pushResultToClient', function () {
       userId: 'TESTUSERID',
       items: [
         {
-          id: 123, hello: 'world', title: 'amazing holiday',
+          type: 'package', id: 123, hello: 'world', title: 'amazing holiday',
           url: 'userId/connectionId/bucketId/123'
         },
         {
-          id: 456, hello: 'world', title: 'not amazing holiday',
+          type: 'package', id: 456, hello: 'world', title: 'not amazing holiday',
           url: 'userId/connectionId/bucketId/456'
         }
       ]
@@ -72,25 +72,30 @@ describe('pushResultToClient', function () {
     });
   });
 
-  it('does not save items without a url to S3', function (done) {
+  it('does not save items with types other than "packge" or "tile" to S3', function (done) {
     var params = {
       id: 'dummyConnectionId', // the session id from WebSocket Server
       searchId: 'ABC',
       userId: 'TESTUSERID',
       items: [
         {
-          id: 123, hello: 'world', title: 'amazing holiday',
+          type: 'package', id: 123, hello: 'world', title: 'amazing holiday',
           url: 'userId/connectionId/bucketId/123'
         },
         {
-          id: 456, hello: 'world', title: 'not amazing holiday'
+          type: 'tile', id: 456, hello: 'world', title: 'amazing holiday',
+          url: 'userId/connectionId/bucketId/123'
+        },
+        {
+          type: 'filter', id: 789, hello: 'world', title: 'not amazing holiday'
         }
       ]
     };
     AwsHelper.pushResultToClient(params, function (err, res) {
       assert(!err);
-      assert.equal(AWS.S3.prototype.upload.callCount, 1);
-      assert.equal(AWS.S3.prototype.upload.lastCall.args[0].Body, JSON.stringify(params.items[0]));
+      assert.equal(AWS.S3.prototype.upload.callCount, 2);
+      assert.equal(AWS.S3.prototype.upload.calls[0].args[0].Body, JSON.stringify(params.items[0]));
+      assert.equal(AWS.S3.prototype.upload.calls[1].args[0].Body, JSON.stringify(params.items[1]));
       done();
     });
   });

--- a/test/lib/pushResultToClient.test.js
+++ b/test/lib/pushResultToClient.test.js
@@ -1,7 +1,9 @@
 // this test needs to run *FIRST* for some reason ... any help figuring out why much appreciated.
 require('env2')('.env');
-var assert = require('assert');
-var AwsHelper = require('./../../lib/index');
+const assert = require('assert');
+const simple = require('simple-mock');
+const AWS = require('aws-sdk');
+const AwsHelper = require('./../../lib/index');
 
 describe('pushResultToClient', function () {
   before('Connect to WebSocket Server', function (done) {
@@ -10,26 +12,108 @@ describe('pushResultToClient', function () {
     });
     done();
   });
+  beforeEach(() => {
+    simple.mock(AWS.S3.prototype, 'upload').callbackWith();
+    simple.mock(AWS.SNS.prototype, 'publish').callbackWith();
+  });
+  afterEach(() => {
+    simple.restore();
+  });
 
-  it('Send result to Client *AND* Save to S3', function (done) {
+  it('publishes results to SNS', (done) => {
     var params = {
       id: 'dummyConnectionId', // the session id from WebSocket Server
       searchId: 'ABC',
       userId: 'TESTUSERID',
-      items: [{
-        id: 123, hello: 'world', title: 'amazing holiday',
-        url: 'userId/connectionId/bucketId/123'
-      }]
+      items: [
+        {
+          id: 123, hello: 'world', title: 'amazing holiday',
+          url: 'userId/connectionId/bucketId/123'
+        },
+        {
+          id: 456, hello: 'world', title: 'not amazing holiday',
+          url: 'userId/connectionId/bucketId/456'
+        }
+      ]
     };
-    AwsHelper.pushResultToClient(params, function (err, res) {
-      // assert(!err);
-      console.log(err);
-      assert.equal(res.Key, 'ci/' + params.items[0].url + '.json');
+    const expected = JSON.stringify({
+      default: JSON.stringify(params)
+    });
+    AwsHelper.pushResultToClient(params, function (err) {
+      assert(!err);
+      assert.equal(AWS.SNS.prototype.publish.callCount, 1);
+      assert.equal(AWS.SNS.prototype.publish.calls[0].args[0].Message, expected);
       done();
     });
   });
 
-  it('Send result to Client *AND* Save to S3 (no SNS Topic)', function (done) {
+  it('saves items to S3', function (done) {
+    var params = {
+      id: 'dummyConnectionId', // the session id from WebSocket Server
+      searchId: 'ABC',
+      userId: 'TESTUSERID',
+      items: [
+        {
+          id: 123, hello: 'world', title: 'amazing holiday',
+          url: 'userId/connectionId/bucketId/123'
+        },
+        {
+          id: 456, hello: 'world', title: 'not amazing holiday',
+          url: 'userId/connectionId/bucketId/456'
+        }
+      ]
+    };
+    AwsHelper.pushResultToClient(params, function (err) {
+      assert(!err);
+      assert.equal(AWS.S3.prototype.upload.callCount, 2);
+      assert.equal(AWS.S3.prototype.upload.calls[0].args[0].Body, JSON.stringify(params.items[0]));
+      assert.equal(AWS.S3.prototype.upload.calls[1].args[0].Body, JSON.stringify(params.items[1]));
+      done();
+    });
+  });
+
+  it('does not save items without a url to S3', function (done) {
+    var params = {
+      id: 'dummyConnectionId', // the session id from WebSocket Server
+      searchId: 'ABC',
+      userId: 'TESTUSERID',
+      items: [
+        {
+          id: 123, hello: 'world', title: 'amazing holiday',
+          url: 'userId/connectionId/bucketId/123'
+        },
+        {
+          id: 456, hello: 'world', title: 'not amazing holiday'
+        }
+      ]
+    };
+    AwsHelper.pushResultToClient(params, function (err, res) {
+      assert(!err);
+      assert.equal(AWS.S3.prototype.upload.callCount, 1);
+      assert.equal(AWS.S3.prototype.upload.lastCall.args[0].Body, JSON.stringify(params.items[0]));
+      done();
+    });
+  });
+
+  it('skips saving to s3 if no items have url properties', function (done) {
+    var params = {
+      id: 'dummyConnectionId', // the session id from WebSocket Server
+      searchId: 'ABC',
+      userId: 'TESTUSERID',
+      items: [
+        {
+          id: 456, hello: 'world', title: 'not amazing holiday'
+        }
+      ]
+    };
+    AwsHelper.pushResultToClient(params, function (err, res) {
+      assert(!err);
+      assert.equal(AWS.S3.prototype.upload.callCount, 0);
+      done();
+    });
+  });
+
+  it('throws an error if SNS topic is not defined', function (done) {
     delete process.env.SEARCH_RESULT_TOPIC;
     var params = {
       id: 'dummyConnectionId', // the session id from WebSocket Server

--- a/test/lib/s3saveget.test.js
+++ b/test/lib/s3saveget.test.js
@@ -10,8 +10,8 @@ var PARAMS = {
   connectionId: 'test1234',
   userId: 'TESTUSERID',
   items: [
-    {id: 0, title: 'my amazing hotel', url: 'test/test/12345'},
-    {id: 1, title: 'my lovely resort', url: 'test/test/45678'}
+    {type: 'package', id: 0, title: 'my amazing hotel', url: 'test/test/12345'},
+    {type: 'tile', id: 1, title: 'my lovely resort', url: 'test/test/45678'}
   ]
 };
 


### PR DESCRIPTION
We want to be able to send items back into the results pipe to the client without also necessarily saving them to s3 as well. In particular, it does not make sense to save items to s3 which do not url.

As such, we remove items from the items array which have no url property before saving to s3.

Also slightly refactor the tests for this method to more explicitly define the calls to downstream AWS services by stubbing the AWS SDK.
