### PR TITLE
Fix for when the invoked lambda doesn't return anything

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,7 @@ AwsHelper.Lambda.invoke = function (params, cb) {
   return AwsHelper._Lambda.invoke(p, function (err, data) {
     if (err) return cb(err);
     var payload = JSON.parse(data.Payload);
-    if (payload.errorMessage) return cb(payload);
+    if (payload && payload.errorMessage) return cb(payload);
     return cb(null, payload);
   });
 };


### PR DESCRIPTION
If the lambda being called calls `callback()` (or doesn't explicitly
call it at all), "payload" is null and looking up a property on it
will throw.
