### PR TITLE
Include provider name when sending results to client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -386,6 +386,7 @@ AwsHelper.pushResultToClient = function (params, callback) {
       // results now only contains the items that were saved to S3 successfully
       var params2 = Object.assign({}, params);
       params2.items = results;
+      params2.provider = AwsHelper._context.functionName;
       pushToSNSTopic(params2, function (err, data) {
         if (err) {
           AwsHelper.log.error({err: err, data: data}, 'ERROR Sending Data via WebSocket');

--- a/test/lib/pushResultToClient.test.js
+++ b/test/lib/pushResultToClient.test.js
@@ -8,7 +8,8 @@ const AwsHelper = require('./../../lib/index');
 describe('pushResultToClient', function () {
   before('Connect to WebSocket Server', function (done) {
     AwsHelper.init({
-      invokedFunctionArn: process.env.INVOKED_FUNCTION_ARN
+      invokedFunctionArn: process.env.INVOKED_FUNCTION_ARN,
+      functionName: 'test-lambda'
     });
     done();
   });
@@ -36,13 +37,12 @@ describe('pushResultToClient', function () {
         }
       ]
     };
-    const expected = JSON.stringify({
-      default: JSON.stringify(params)
-    });
+    const expected = Object.assign({ provider: 'test-lambda' }, params);
     AwsHelper.pushResultToClient(params, function (err) {
       assert(!err);
       assert.equal(AWS.SNS.prototype.publish.callCount, 1);
-      assert.equal(AWS.SNS.prototype.publish.calls[0].args[0].Message, expected);
+      const message = JSON.parse(JSON.parse(AWS.SNS.prototype.publish.calls[0].args[0].Message).default);
+      assert.deepEqual(message, expected);
       done();
     });
   });


### PR DESCRIPTION
This will help us better trace results through the pipeline, and make debugging easier, as well as allowing the client to be aware of what providers are registered for future purposes around having providers emit complete events.
