### PR TITLE
Allow `pushResultToClient` to send events with no items

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -351,13 +351,11 @@ AwsHelper.pushResultToClient = function (params, callback) {
     return callback(new Error(msg));
   }
 
+  params.items = Array.isArray(params.items) ? params.items : [];
+
   var filtered = params.items.filter(function (item) {
     return item.url;
   });
-
-  if (filtered.length === 0) {
-    return callback(new Error('no valid items to save!'));
-  }
 
   A.filterLimit(
     filtered,

--- a/test/lib/pushResultToClient.test.js
+++ b/test/lib/pushResultToClient.test.js
@@ -112,8 +112,22 @@ describe('pushResultToClient', function () {
       ]
     };
     AwsHelper.pushResultToClient(params, function (err, res) {
-      assert(err);
+      assert(!err);
       assert.equal(AWS.S3.prototype.upload.callCount, 0);
+      done();
+    });
+  });
+
+  it('emits sns events if there are no items', function (done) {
+    var params = {
+      id: 'dummyConnectionId', // the session id from WebSocket Server
+      searchId: 'ABC',
+      userId: 'TESTUSERID',
+      items: []
+    };
+    AwsHelper.pushResultToClient(params, function (err, res) {
+      assert(!err);
+      assert.equal(AWS.SNS.prototype.publish.callCount, 1);
       done();
     });
   });


### PR DESCRIPTION
There are occasions when we need to be able to send messages from providers back to the UI that do not have search results attached. For example "search complete" events. As such we need to stop the function from throwing an error if no `items` are sent.

Instead allow the SNS event to continue to be emitted, even if there are no `items` provided.
